### PR TITLE
Shard seeder update

### DIFF
--- a/src/uhs/atomizer/sentinel/controller.hpp
+++ b/src/uhs/atomizer/sentinel/controller.hpp
@@ -8,14 +8,13 @@
 
 #include "server.hpp"
 #include "uhs/sentinel/interface.hpp"
+#include "uhs/transaction/transaction.hpp"
 #include "util/common/config.hpp"
 #include "util/network/connection_manager.hpp"
-#include "uhs/transaction/transaction.hpp"
-
-#include <secp256k1.h>
-#include <secp256k1_bulletproofs.h>
 
 #include <memory>
+#include <secp256k1.h>
+#include <secp256k1_bulletproofs.h>
 
 namespace cbdc::sentinel {
     /// Sentinel implementation.

--- a/src/uhs/atomizer/shard/shard.cpp
+++ b/src/uhs/atomizer/shard/shard.cpp
@@ -67,24 +67,30 @@ namespace cbdc::shard {
             for(const auto& out : tx.m_outputs) {
                 if(is_output_on_shard(out.m_id)) {
                     std::array<char, sizeof(out.m_id)> out_arr{};
-                    std::memcpy(out_arr.data(), out.m_id.data(), out.m_id.size());
-                    leveldb::Slice OutPointKey(out_arr.data(), out.m_id.size());
+                    std::memcpy(out_arr.data(),
+                                out.m_id.data(),
+                                out.m_id.size());
+                    leveldb::Slice OutPointKey(out_arr.data(),
+                                               out.m_id.size());
 
-                    std::array<char, sizeof(out.m_auxiliary) +
-                                     sizeof(out.m_range) +
-                                     sizeof(out.m_consistency)> proofs_arr{};
-                    auto pptr = proofs_arr.data();
+                    std::array<char,
+                               sizeof(out.m_auxiliary) + sizeof(out.m_range)
+                                   + sizeof(out.m_consistency)>
+                        proofs_arr{};
+                    auto* pptr = proofs_arr.data();
 
-                    std::memcpy(pptr, out.m_auxiliary.data(),
-                        out.m_auxiliary.size());
+                    std::memcpy(pptr,
+                                out.m_auxiliary.data(),
+                                out.m_auxiliary.size());
                     pptr += out.m_auxiliary.size();
                     std::memcpy(pptr, out.m_range.data(), out.m_range.size());
                     pptr += out.m_range.size();
-                    std::memcpy(pptr, out.m_consistency.data(),
-                        out.m_consistency.size());
+                    std::memcpy(pptr,
+                                out.m_consistency.data(),
+                                out.m_consistency.size());
 
                     leveldb::Slice ProofVal(proofs_arr.data(),
-                        proofs_arr.size());
+                                            proofs_arr.size());
                     batch.Put(OutPointKey, ProofVal);
                 }
             }

--- a/src/uhs/client/atomizer_client.cpp
+++ b/src/uhs/client/atomizer_client.cpp
@@ -52,7 +52,7 @@ namespace cbdc {
                            ctx.m_outputs.end(),
                            std::back_inserter(uhs_ids),
                            [](transaction::compact_output p) -> hash_t {
-                            return p.m_id;
+                               return p.m_id;
                            });
             it->second.insert(it->second.end(),
                               uhs_ids.begin(),

--- a/src/uhs/client/client.hpp
+++ b/src/uhs/client/client.hpp
@@ -310,18 +310,25 @@ namespace cbdc {
                    &secp256k1_context_destroy};
 
         struct GensDeleter {
-            GensDeleter(secp256k1_context* ctx) : m_ctx(ctx) {}
+            explicit GensDeleter(secp256k1_context* ctx) : m_ctx(ctx) {}
 
-            void operator()(secp256k1_bulletproofs_generators* gens) {
+            void operator()(secp256k1_bulletproofs_generators* gens) const {
                 secp256k1_bulletproofs_generators_destroy(m_ctx, gens);
             }
 
             secp256k1_context* m_ctx;
         };
 
+        /// should be twice the bitcount of the range-proof's upper bound
+        ///
+        /// e.g., if proving things in the range [0, 2^64-1], it should be 128.
+        static const inline auto generator_count = 129;
+
         std::unique_ptr<secp256k1_bulletproofs_generators, GensDeleter>
-            m_generators{secp256k1_bulletproofs_generators_create(m_secp.get(),
-                128), GensDeleter(m_secp.get())};
+            m_generators{
+                secp256k1_bulletproofs_generators_create(m_secp.get(),
+                    generator_count),
+                GensDeleter(m_secp.get())};
     };
 }
 

--- a/src/uhs/transaction/messages.cpp
+++ b/src/uhs/transaction/messages.cpp
@@ -23,8 +23,8 @@ namespace cbdc {
     auto operator<<(serializer& packet, const transaction::output& out)
         -> serializer& {
         return packet << out.m_witness_program_commitment << out.m_id
-            << out.m_nonce << out.m_auxiliary << out.m_range
-            << out.m_consistency;
+                      << out.m_nonce << out.m_auxiliary << out.m_range
+                      << out.m_consistency;
     }
 
     auto operator>>(serializer& packet, transaction::output& out)
@@ -37,7 +37,7 @@ namespace cbdc {
     auto operator<<(serializer& packet, const transaction::compact_output& out)
         -> serializer& {
         return packet << out.m_id << out.m_auxiliary << out.m_range
-            << out.m_consistency;
+                      << out.m_consistency;
     }
 
     auto operator>>(serializer& packet, transaction::compact_output& out)
@@ -59,7 +59,7 @@ namespace cbdc {
     auto operator<<(serializer& packet, const transaction::input& inp)
         -> serializer& {
         return packet << inp.m_prevout << inp.m_prevout_data
-            << inp.m_spend_data;
+                      << inp.m_spend_data;
     }
 
     auto operator>>(serializer& packet, transaction::input& inp)
@@ -71,7 +71,7 @@ namespace cbdc {
     auto operator<<(serializer& packet, const transaction::full_tx& tx)
         -> serializer& {
         return packet << tx.m_inputs << tx.m_outputs << tx.m_witness
-            << tx.m_tx_proofs << tx.m_out_spend_data;
+                      << tx.m_tx_proofs << tx.m_out_spend_data;
     }
 
     auto operator>>(serializer& packet, transaction::full_tx& tx)
@@ -81,12 +81,13 @@ namespace cbdc {
     }
 
     auto operator<<(serializer& packet,
-        const transaction::transaction_proof& proof) -> serializer& {
+                    const transaction::transaction_proof& proof)
+        -> serializer& {
         return packet << proof.m_noncesigs;
     }
 
-    auto operator>>(serializer& packet,
-        transaction::transaction_proof& proof) -> serializer& {
+    auto operator>>(serializer& packet, transaction::transaction_proof& proof)
+        -> serializer& {
         return packet >> proof.m_noncesigs;
     }
 

--- a/src/uhs/transaction/messages.hpp
+++ b/src/uhs/transaction/messages.hpp
@@ -102,14 +102,15 @@ namespace cbdc {
     /// \see \ref cbdc::operator<<(serializer&, const std::array<T, len>&)
     /// \see \ref cbdc::operator<<(serializer&, const std::vector<T>&)
     auto operator<<(serializer& packet,
-        const transaction::transaction_proof& proof) -> serializer&;
+                    const transaction::transaction_proof& proof)
+        -> serializer&;
 
     /// \brief Deserializes transaction-wide cryptographic proofs
     ///
     /// Deserializes the vector of signatures on the UHS-ID compression nonces.
     /// \see \ref cbdc::operator<<(serializer&, const transaction::transaction_proof&)
-    auto operator>>(serializer& packet,
-        transaction::transaction_proof& proof) -> serializer&;
+    auto operator>>(serializer& packet, transaction::transaction_proof& proof)
+        -> serializer&;
 
     /// \brief Serializes a compact transaction.
     ///

--- a/src/uhs/transaction/transaction.cpp
+++ b/src/uhs/transaction/transaction.cpp
@@ -25,10 +25,8 @@ namespace cbdc::transaction {
 
     auto output::operator==(const output& rhs) const -> bool {
         return m_witness_program_commitment == rhs.m_witness_program_commitment
-            && m_id == rhs.m_id
-            && m_nonce == rhs.m_nonce
-            && m_auxiliary == rhs.m_auxiliary
-            && m_range == rhs.m_range
+            && m_id == rhs.m_id && m_nonce == rhs.m_nonce
+            && m_auxiliary == rhs.m_auxiliary && m_range == rhs.m_range
             && m_consistency == rhs.m_consistency;
     }
 
@@ -42,15 +40,18 @@ namespace cbdc::transaction {
           m_range(put.m_range),
           m_consistency(put.m_consistency) {}
 
-    compact_output::compact_output(const hash_t& id, const commitment_t& aux,
-        const rangeproof_t<>& range, const signature_t& consist)
-        : m_id(id), m_auxiliary(aux), m_range(range), m_consistency(consist) {}
+    compact_output::compact_output(const hash_t& id,
+                                   const commitment_t& aux,
+                                   const rangeproof_t<>& range,
+                                   const signature_t& consist)
+        : m_id(id),
+          m_auxiliary(aux),
+          m_range(range),
+          m_consistency(consist) {}
 
     auto compact_output::operator==(const compact_output& rhs) const -> bool {
-        return m_id == rhs.m_id
-            && m_auxiliary == rhs.m_auxiliary
-            && m_range == rhs.m_range
-            && m_consistency == rhs.m_consistency;
+        return m_id == rhs.m_id && m_auxiliary == rhs.m_auxiliary
+            && m_range == rhs.m_range && m_consistency == rhs.m_consistency;
     }
 
     auto compact_output::operator!=(const compact_output& rhs) const -> bool {
@@ -71,7 +72,7 @@ namespace cbdc::transaction {
         auto opt_buf = cbdc::make_buffer(this->m_prevout);
         sha.Write(opt_buf.c_ptr(), opt_buf.size());
         sha.Write(this->m_prevout_data.m_witness_program_commitment.data(),
-            sizeof(hash_t));
+                  sizeof(hash_t));
 
         hash_t result;
         sha.Finalize(result.data());
@@ -99,8 +100,7 @@ namespace cbdc::transaction {
         }
 
         for(const auto& out : tx.m_outputs) {
-            sha.Write(out.m_witness_program_commitment.data(),
-                sizeof(hash_t));
+            sha.Write(out.m_witness_program_commitment.data(), sizeof(hash_t));
         }
 
         hash_t ret;
@@ -129,28 +129,31 @@ namespace cbdc::transaction {
     }
 
     auto output_preimage(const out_point& point, const output& put)
-    -> std::array<unsigned char, sizeof(compact_tx::m_id) +
-        sizeof(out_point::m_index) +
-        sizeof(output::m_witness_program_commitment)> {
-        std::array<unsigned char, sizeof(compact_tx::m_id) +
-            sizeof(out_point::m_index) +
-            sizeof(output::m_witness_program_commitment)> buf{};
+        -> std::array<unsigned char,
+                      sizeof(compact_tx::m_id) + sizeof(out_point::m_index)
+                          + sizeof(output::m_witness_program_commitment)> {
+        std::array<unsigned char,
+                   sizeof(compact_tx::m_id) + sizeof(out_point::m_index)
+                       + sizeof(output::m_witness_program_commitment)>
+            buf{};
 
-        auto bptr = buf.data();
+        auto* bptr = buf.data();
         std::memcpy(bptr, point.m_tx_id.data(), point.m_tx_id.size());
         bptr += sizeof(compact_tx::m_id);
         std::memcpy(bptr, &point.m_index, sizeof(point.m_index));
         bptr += sizeof(out_point::m_index);
-        std::memcpy(bptr, put.m_witness_program_commitment.data(),
-            put.m_witness_program_commitment.size());
+        std::memcpy(bptr,
+                    put.m_witness_program_commitment.data(),
+                    put.m_witness_program_commitment.size());
 
         return buf;
     }
 
-    auto output_randomness(std::array<unsigned char, sizeof(compact_tx::m_id) +
-        sizeof(out_point::m_index) +
-        sizeof(output::m_witness_program_commitment)> buf, const hash_t& nonce)
-    -> hash_t {
+    auto output_randomness(
+        std::array<unsigned char,
+                   sizeof(compact_tx::m_id) + sizeof(out_point::m_index)
+                       + sizeof(output::m_witness_program_commitment)> buf,
+        const hash_t& nonce) -> hash_t {
         const auto bufsize = buf.size();
 
         CSHA256 sha;
@@ -162,16 +165,18 @@ namespace cbdc::transaction {
         return candidate;
     }
 
-    auto calculate_uhs_id(secp256k1_context* ctx, random_source& rng,
-        std::array<unsigned char, sizeof(compact_tx::m_id) +
-        sizeof(out_point::m_index) +
-        sizeof(output::m_witness_program_commitment)> buf, uint64_t value)
-    -> std::pair<hash_t, hash_t> {
-        while ( true ) {
+    auto calculate_uhs_id(
+        secp256k1_context* ctx,
+        random_source& rng,
+        std::array<unsigned char,
+                   sizeof(compact_tx::m_id) + sizeof(out_point::m_index)
+                       + sizeof(output::m_witness_program_commitment)> buf,
+        uint64_t value) -> std::pair<hash_t, hash_t> {
+        while(true) {
             auto t = rng.random_hash();
             auto candidate = output_randomness(buf, t);
             auto c = make_xonly_commitment(ctx, value, candidate);
-            if ( c.has_value() ) {
+            if(c.has_value()) {
                 return std::make_pair(c.value(), t);
             }
         }
@@ -179,19 +184,21 @@ namespace cbdc::transaction {
         __builtin_unreachable();
     }
 
-    auto calculate_uhs_id(secp256k1_context* ctx, random_source& rng,
-        const out_point& point, const output& put, uint64_t value)
-    -> std::pair<hash_t, hash_t> {
+    auto calculate_uhs_id(secp256k1_context* ctx,
+                          random_source& rng,
+                          const out_point& point,
+                          const output& put,
+                          uint64_t value) -> std::pair<hash_t, hash_t> {
         auto buf = output_preimage(point, put);
         return calculate_uhs_id(ctx, rng, buf, value);
     }
 
-    auto roll_auxiliaries(secp256k1_context* ctx, random_source& rng,
-        const std::vector<hash_t>& blinds,
-        std::vector<spend_data>& out_spend_data)
-    -> std::vector<secp256k1_pedersen_commitment> {
-
-        const auto make_public = blinds.size() == 0;
+    auto roll_auxiliaries(secp256k1_context* ctx,
+                          random_source& rng,
+                          const std::vector<hash_t>& blinds,
+                          std::vector<spend_data>& out_spend_data)
+        -> std::vector<secp256k1_pedersen_commitment> {
+        const auto make_public = blinds.empty();
         const hash_t empty{};
 
         std::vector<secp256k1_pedersen_commitment> auxiliaries{};
@@ -200,7 +207,8 @@ namespace cbdc::transaction {
         for(uint64_t i = 0; i < out_spend_data.size() - 1; ++i) {
             while(true) {
                 auto rprime = make_public ? empty : rng.random_hash();
-                auto commitment = commit(ctx, out_spend_data[i].m_value, rprime);
+                auto commitment
+                    = commit(ctx, out_spend_data[i].m_value, rprime);
                 if(commitment.has_value()) {
                     auxiliaries.push_back(commitment.value());
                     new_blinds.push_back(rprime);
@@ -212,26 +220,31 @@ namespace cbdc::transaction {
 
         if(!make_public) {
             std::vector<hash_t> allblinds{blinds};
-            std::copy(new_blinds.begin(), new_blinds.end(),
-                std::back_inserter(allblinds));
+            std::copy(new_blinds.begin(),
+                      new_blinds.end(),
+                      std::back_inserter(allblinds));
 
-            std::vector<const unsigned char *> blind_ptrs;
+            std::vector<const unsigned char*> blind_ptrs;
             blind_ptrs.reserve(allblinds.size());
             for(const auto& b : allblinds) {
                 blind_ptrs.push_back(b.data());
             }
 
             hash_t last_blind{};
-            [[maybe_unused]] auto ret = secp256k1_pedersen_blind_sum(ctx,
-                last_blind.data(), blind_ptrs.data(), allblinds.size(),
-                blinds.size());
+            [[maybe_unused]] auto ret
+                = secp256k1_pedersen_blind_sum(ctx,
+                                               last_blind.data(),
+                                               blind_ptrs.data(),
+                                               allblinds.size(),
+                                               blinds.size());
             assert(ret == 1);
-            auxiliaries.push_back(commit(ctx, out_spend_data.back().m_value,
-                last_blind).value());
+            auxiliaries.push_back(
+                commit(ctx, out_spend_data.back().m_value, last_blind)
+                    .value());
             out_spend_data.back().m_blind = last_blind;
         } else {
-            auxiliaries.push_back(commit(ctx, out_spend_data.back().m_value,
-                empty).value());
+            auxiliaries.push_back(
+                commit(ctx, out_spend_data.back().m_value, empty).value());
             new_blinds.push_back(empty);
             out_spend_data.back().m_blind = empty;
         }
@@ -240,13 +253,15 @@ namespace cbdc::transaction {
     }
 
     auto prove_output(secp256k1_context* ctx,
-        secp256k1_bulletproofs_generators* gens, random_source& rng,
-        output& put, const out_point& point, const spend_data& out_spend_data,
-        const secp256k1_pedersen_commitment* auxiliary)
-    -> bool {
+                      secp256k1_bulletproofs_generators* gens,
+                      random_source& rng,
+                      output& put,
+                      const out_point& point,
+                      const spend_data& out_spend_data,
+                      const secp256k1_pedersen_commitment* auxiliary) -> bool {
         const auto out_preimage = output_preimage(point, put);
-        auto [ uhs, nonce ] = calculate_uhs_id(ctx, rng, out_preimage, 
-            out_spend_data.m_value);
+        auto [uhs, nonce]
+            = calculate_uhs_id(ctx, rng, out_preimage, out_spend_data.m_value);
 
         put.m_id = uhs;
         put.m_nonce = nonce;
@@ -254,8 +269,8 @@ namespace cbdc::transaction {
         // manually derive the secret key
         auto esk = output_randomness(out_preimage, nonce);
         auto rprime = out_spend_data.m_blind;
-        [[maybe_unused]] auto ret = secp256k1_ec_seckey_negate(ctx,
-            rprime.data());
+        [[maybe_unused]] auto ret
+            = secp256k1_ec_seckey_negate(ctx, rprime.data());
         // fails when rprime == 0 (which is fine)
         ret = secp256k1_ec_seckey_tweak_add(ctx, esk.data(), rprime.data());
         assert(ret == 1);
@@ -265,8 +280,13 @@ namespace cbdc::transaction {
         assert(ret == 1);
 
         auto consistency = signature_t{};
-        unsigned char consist_contents [32] = "consistent proof";
-        ret = secp256k1_schnorrsig_sign(ctx, consistency.data(), consist_contents, &kp, nullptr, nullptr);
+        unsigned char consist_contents[32] = "consistent proof";
+        ret = secp256k1_schnorrsig_sign(ctx,
+                                        consistency.data(),
+                                        consist_contents,
+                                        &kp,
+                                        nullptr,
+                                        nullptr);
         assert(ret == 1);
 
         put.m_consistency = consistency;
@@ -274,7 +294,10 @@ namespace cbdc::transaction {
         rangeproof_t<> range{};
         size_t rangelen = range.size();
         ret = secp256k1_bulletproofs_rangeproof_uncompressed_prove(
-            ctx, gens, secp256k1_generator_h, range.data(),
+            ctx,
+            gens,
+            secp256k1_generator_h,
+            range.data(),
             &rangelen,
             64, // 2^64-1
             out_spend_data.m_value,
@@ -282,8 +305,8 @@ namespace cbdc::transaction {
             auxiliary, // the auxiliary commitment for this output
             out_spend_data.m_blind.data(),
             rng.random_hash().data(),
-            NULL, // enc_data
-            NULL, // extra_commit
+            nullptr, // enc_data
+            nullptr, // extra_commit
             0     // extra_commit length
         );
         assert(ret == 1);
@@ -294,21 +317,27 @@ namespace cbdc::transaction {
         return true;
     }
 
-    auto sign_nonces(secp256k1_context* ctx, std::vector<unsigned char> nonces,
+    auto sign_nonces(
+        secp256k1_context* ctx,
+        std::vector<unsigned char> nonces,
         const std::vector<std::pair<privkey_t, pubkey_t>>& spending_keys)
-    -> std::vector<signature_t> {
+        -> std::vector<signature_t> {
         std::vector<signature_t> noncesigs{};
         noncesigs.reserve(spending_keys.size());
         for(size_t i = 0; i < spending_keys.size(); ++i) {
-            const auto& [ sk, pk ] = spending_keys[i];
+            const auto& [sk, pk] = spending_keys[i];
             secp256k1_keypair spending_kp{};
-            [[maybe_unused]] auto ret = secp256k1_keypair_create(ctx,
-                &spending_kp, sk.data());
+            [[maybe_unused]] auto ret
+                = secp256k1_keypair_create(ctx, &spending_kp, sk.data());
             assert(ret == 1);
 
             signature_t noncesig{};
-            ret = secp256k1_schnorrsig_sign(ctx, noncesig.data(),
-                nonces.data(), &spending_kp, nullptr, nullptr);
+            ret = secp256k1_schnorrsig_sign(ctx,
+                                            noncesig.data(),
+                                            nonces.data(),
+                                            &spending_kp,
+                                            nullptr,
+                                            nullptr);
             assert(ret == 1);
 
             noncesigs[i] = noncesig;
@@ -317,12 +346,13 @@ namespace cbdc::transaction {
         return noncesigs;
     }
 
-    auto add_proof(secp256k1_context* ctx,
-        secp256k1_bulletproofs_generators* gens, random_source& rng,
-        full_tx& tx,
-        const std::vector<std::pair<privkey_t, pubkey_t>>& spending_keys)
-    -> bool {
-
+    auto
+    add_proof(secp256k1_context* ctx,
+              secp256k1_bulletproofs_generators* gens,
+              random_source& rng,
+              full_tx& tx,
+              const std::vector<std::pair<privkey_t, pubkey_t>>& spending_keys)
+        -> bool {
         std::vector<hash_t> blinds{};
         for(const auto& inp : tx.m_inputs) {
             auto spend_data = inp.m_spend_data;
@@ -345,17 +375,21 @@ namespace cbdc::transaction {
             }
         }
 
-        auto auxiliaries = roll_auxiliaries(ctx, rng, blinds,
-            tx.m_out_spend_data.value());
+        auto auxiliaries
+            = roll_auxiliaries(ctx, rng, blinds, tx.m_out_spend_data.value());
 
         const auto txid = tx_id(tx);
 
         for(uint64_t i = 0; i < tx.m_outputs.size(); ++i) {
-            [[maybe_unused]] auto res = prove_output(ctx, gens, rng,
+            [[maybe_unused]] auto res = prove_output(
+                ctx,
+                gens,
+                rng,
                 tx.m_outputs[i],
                 input_from_output(tx, i, txid).value().m_prevout,
-                tx.m_out_spend_data.value()[i], &auxiliaries[i]);
-            if(res != 1) {
+                tx.m_out_spend_data.value()[i],
+                &auxiliaries[i]);
+            if(!res) {
                 return false;
             }
         }
@@ -363,7 +397,7 @@ namespace cbdc::transaction {
         // todo: blind spend-required data after adding proof
         //       (unclear quite when this should happen)
         // todo: same for m_out_spend_data?
-        //for(auto& inp : tx.m_inputs) {
+        // for(auto& inp : tx.m_inputs) {
         //    inp.m_spend_data = std::nullopt;
         //}
 

--- a/src/uhs/transaction/transaction.hpp
+++ b/src/uhs/transaction/transaction.hpp
@@ -6,18 +6,17 @@
 #ifndef OPENCBDC_TX_SRC_TRANSACTION_TRANSACTION_H_
 #define OPENCBDC_TX_SRC_TRANSACTION_TRANSACTION_H_
 
-#include "util/common/random_source.hpp"
-#include "util/common/commitment.hpp"
 #include "crypto/sha256.h"
+#include "util/common/commitment.hpp"
 #include "util/common/hash.hpp"
 #include "util/common/keys.hpp"
+#include "util/common/random_source.hpp"
 #include "util/serialization/format.hpp"
 #include "util/serialization/util.hpp"
 
-#include <secp256k1_schnorrsig.h>
-
 #include <cstdint>
 #include <optional>
+#include <secp256k1_schnorrsig.h>
 #include <utility>
 
 namespace cbdc::transaction {
@@ -55,15 +54,15 @@ namespace cbdc::transaction {
         /// Hash of the witness program
         hash_t m_witness_program_commitment{};
         /// The UHS ID for the output
-        hash_t m_id;
+        hash_t m_id{};
         /// The nonce used to compress the Pedersen Commitment to 32 bytes
-        hash_t m_nonce;
+        hash_t m_nonce{};
         /// An auxiliary value used to prove preservation of balance
-        commitment_t m_auxiliary;
+        commitment_t m_auxiliary{};
         /// The rangeproof guaranteeing that the output is greater than 0
-        rangeproof_t<> m_range;
+        rangeproof_t<> m_range{};
         /// The signature proving consistency
-        signature_t m_consistency;
+        signature_t m_consistency{};
 
         auto operator==(const output& rhs) const -> bool;
         auto operator!=(const output& rhs) const -> bool;
@@ -84,9 +83,10 @@ namespace cbdc::transaction {
     /// \param put the \ref output to-be-spent
     /// \returns a pair of the commitment, and the random nonce that was
     ///          committed to
-    auto calculate_uhs_id(secp256k1_context* ctx, random_source& rng,
-        const out_point& point, const output& put)
-        -> std::pair<hash_t, hash_t>;
+    auto calculate_uhs_id(secp256k1_context* ctx,
+                          random_source& rng,
+                          const out_point& point,
+                          const output& put) -> std::pair<hash_t, hash_t>;
 
     /// \brief Additional information a spender needs to spend an input
     struct spend_data {
@@ -171,15 +171,17 @@ namespace cbdc::transaction {
         /// The signature proving consistency
         signature_t m_consistency{};
 
-        compact_output(const output& put);
-        compact_output(const hash_t& id, const commitment_t& aux,
-            const rangeproof_t<>& range, const signature_t& consist);
+        explicit compact_output(const output& put);
+
+        compact_output(const hash_t& id,
+                       const commitment_t& aux,
+                       const rangeproof_t<>& range,
+                       const signature_t& consist);
         compact_output() = default;
 
         auto operator==(const compact_output& rhs) const -> bool;
         auto operator!=(const compact_output& rhs) const -> bool;
     };
-
 
     /// \brief A condensed, hash-only transaction representation
     ///
@@ -219,10 +221,11 @@ namespace cbdc::transaction {
     /// \param blinds the blinding factors, one per-input (in order)
     /// \param out_spend_data the additional spend data (in output order)
     /// \return the created commitments (in output order)
-    auto roll_auxiliaries(secp256k1_context* ctx, random_source& rng,
-        const std::vector<hash_t>& blinds,
-        std::vector<spend_data>& out_spend_data)
-    -> std::vector<secp256k1_pedersen_commitment>;
+    auto roll_auxiliaries(secp256k1_context* ctx,
+                          random_source& rng,
+                          const std::vector<hash_t>& blinds,
+                          std::vector<spend_data>& out_spend_data)
+        -> std::vector<secp256k1_pedersen_commitment>;
 
     /// \brief Add cryptographic proof to a single output
     ///
@@ -239,10 +242,12 @@ namespace cbdc::transaction {
     /// \return true if all proofs were correctly added to the output,
     ///         false otherwise
     auto prove_output(secp256k1_context* ctx,
-        secp256k1_bulletproofs_generators* gens, random_source& rng,
-        output& put, const out_point& point, const spend_data& out_spend_data,
-        const secp256k1_pedersen_commitment* auxiliary)
-    -> bool;
+                      secp256k1_bulletproofs_generators* gens,
+                      random_source& rng,
+                      output& put,
+                      const out_point& point,
+                      const spend_data& out_spend_data,
+                      const secp256k1_pedersen_commitment* auxiliary) -> bool;
 
     /// \brief Update a transaction with cryptographic proofs
     ///
@@ -256,13 +261,14 @@ namespace cbdc::transaction {
     /// \param rng a random_source for generating nonces
     /// \param tx the new transaction for which proofs will be created
     /// \param spending_keys the private keys corresponding to the inputs
-    /// \param out_spend_data the additional spend data (in output order)
-    /// \return the new blinding factor set, one per-output (in order)
-    auto add_proof(secp256k1_context* ctx,
-        secp256k1_bulletproofs_generators* gens, random_source& rng,
-        full_tx& tx,
-        const std::vector<std::pair<privkey_t, pubkey_t>>& spending_keys)
-    -> bool;
+    /// \return true if proving was successful; false otherwise
+    auto
+    add_proof(secp256k1_context* ctx,
+              secp256k1_bulletproofs_generators* gens,
+              random_source& rng,
+              full_tx& tx,
+              const std::vector<std::pair<privkey_t, pubkey_t>>& spending_keys)
+        -> bool;
 
     /// \brief Calculates the unique hash of a full transaction
     ///

--- a/src/uhs/transaction/validation.cpp
+++ b/src/uhs/transaction/validation.cpp
@@ -18,23 +18,29 @@ namespace cbdc::transaction::validation {
     static const auto secp_context
         = std::unique_ptr<secp256k1_context,
                           decltype(&secp256k1_context_destroy)>(
-            secp256k1_context_create(SECP256K1_CONTEXT_SIGN 
-                | SECP256K1_CONTEXT_VERIFY),
+            secp256k1_context_create(SECP256K1_CONTEXT_SIGN
+                                     | SECP256K1_CONTEXT_VERIFY),
             &secp256k1_context_destroy);
 
     struct GensDeleter {
-        GensDeleter(secp256k1_context* ctx) : m_ctx(ctx) {}
+        explicit GensDeleter(secp256k1_context* ctx) : m_ctx(ctx) {}
 
-        void operator()(secp256k1_bulletproofs_generators* gens) {
+        void operator()(secp256k1_bulletproofs_generators* gens) const {
             secp256k1_bulletproofs_generators_destroy(m_ctx, gens);
         }
 
         secp256k1_context* m_ctx;
     };
 
-    std::unique_ptr<secp256k1_bulletproofs_generators, GensDeleter>
-        generators{secp256k1_bulletproofs_generators_create(
-            secp_context.get(), 128), GensDeleter(secp_context.get())};
+    /// should be twice the bitcount of the range-proof's upper bound
+    ///
+    /// e.g., if proving things in the range [0, 2^64-1], it should be 128.
+    static const auto inline generator_count = 128;
+
+    std::unique_ptr<secp256k1_bulletproofs_generators, GensDeleter> generators{
+        secp256k1_bulletproofs_generators_create(secp_context.get(),
+            generator_count),
+        GensDeleter(secp_context.get())};
 
     auto input_error::operator==(const input_error& rhs) const -> bool {
         return std::tie(m_code, m_data_err, m_idx)
@@ -254,13 +260,11 @@ namespace cbdc::transaction::validation {
     }
 
     auto check_proof(const compact_tx& tx) -> std::optional<proof_error> {
-        auto ctx = secp_context.get();
-        secp256k1_scratch_space * scratch = secp256k1_scratch_space_create(ctx,
-            100 * 1024);
+        auto* ctx = secp_context.get();
+        secp256k1_scratch_space* scratch
+            = secp256k1_scratch_space_create(ctx, 100 * 1024);
         std::vector<secp256k1_pedersen_commitment> auxiliaries{};
-        for (size_t i = 0; i < tx.m_outputs.size(); ++i) {
-            const auto& proof = tx.m_outputs[i];
-
+        for(const auto& proof : tx.m_outputs) {
             std::array<secp256k1_pubkey, 2> points{};
 
             auto maybe_aux = deserialize_commitment(ctx, proof.m_auxiliary);
@@ -274,7 +278,8 @@ namespace cbdc::transaction::validation {
             auto ret = secp256k1_ec_pubkey_negate(ctx, &points[0]);
             assert(ret == 1);
 
-            auto maybe_comm = expand_xonly_commitment(ctx, proof.m_id);
+            hash_t uhs_id = proof.m_id;
+            auto maybe_comm = expand_xonly_commitment(ctx, uhs_id);
             if(!maybe_comm.has_value()) {
                 return proof_error{proof_error_code::invalid_uhs_id};
             }
@@ -282,7 +287,7 @@ namespace cbdc::transaction::validation {
 
             secp256k1_pedersen_commitment_as_key(&comm, &points[1]);
 
-            const secp256k1_pubkey * pks [2];
+            const secp256k1_pubkey* pks[2];
             pks[0] = &points[0];
             pks[1] = &points[1];
 
@@ -294,27 +299,34 @@ namespace cbdc::transaction::validation {
 
             secp256k1_xonly_pubkey epk{};
             [[maybe_unused]] int parity{};
-            ret = secp256k1_xonly_pubkey_from_pubkey(ctx, &epk, &parity,
-                &fullepk);
+            ret = secp256k1_xonly_pubkey_from_pubkey(ctx,
+                                                     &epk,
+                                                     &parity,
+                                                     &fullepk);
             if(ret != 1) {
                 return proof_error{proof_error_code::invalid_signature_key};
             }
 
-            unsigned char consist_contents [32] = "consistent proof";
-            ret = secp256k1_schnorrsig_verify(ctx, proof.m_consistency.data(),
-                    consist_contents, &epk);
+            unsigned char consist_contents[32] = "consistent proof";
+            ret = secp256k1_schnorrsig_verify(ctx,
+                                              proof.m_consistency.data(),
+                                              consist_contents,
+                                              &epk);
             if(ret != 1) {
                 return proof_error{proof_error_code::inconsistent_value};
             }
 
-            ret = secp256k1_bulletproofs_rangeproof_uncompressed_verify(ctx,
-                scratch, generators.get(), secp256k1_generator_h,
+            ret = secp256k1_bulletproofs_rangeproof_uncompressed_verify(
+                ctx,
+                scratch,
+                generators.get(),
+                secp256k1_generator_h,
                 proof.m_range.data(),
                 proof.m_range.size(),
                 0, // minimum
                 &aux,
                 nullptr, // extra commit
-                0 // extra commit length
+                0        // extra commit length
             );
 
             if(ret != 1) {
@@ -332,8 +344,7 @@ namespace cbdc::transaction::validation {
     auto check_commitment_sum(
         const std::vector<secp256k1_pedersen_commitment>& auxiliaries,
         uint64_t minted) -> bool {
-
-        std::vector<const secp256k1_pedersen_commitment *> aux_ptrs{};
+        std::vector<const secp256k1_pedersen_commitment*> aux_ptrs{};
         aux_ptrs.reserve(auxiliaries.size());
         for(const auto aux : auxiliaries) {
             aux_ptrs.push_back(&aux);
@@ -346,8 +357,11 @@ namespace cbdc::transaction::validation {
         }
 
         return secp256k1_pedersen_verify_tally(secp_context.get(),
-            aux_ptrs.data(), auxiliaries.size() - 1,
-            &aux_ptrs.back(), 1) == 1;
+                                               aux_ptrs.data(),
+                                               auxiliaries.size() - 1,
+                                               &aux_ptrs.back(),
+                                               1)
+            == 1;
     }
 
     auto get_p2pk_witness_commitment(const pubkey_t& payee) -> hash_t {
@@ -416,26 +430,25 @@ namespace cbdc::transaction::validation {
     auto to_string(const cbdc::transaction::validation::proof_error& err)
         -> std::string {
         switch(err.m_code) {
-            case cbdc::transaction::validation::proof_error_code
-                ::invalid_auxiliary:
+            case cbdc::transaction::validation::proof_error_code ::
+                invalid_auxiliary:
                 return "One or more auxiliary commitments were malformed";
-            case cbdc::transaction::validation::proof_error_code
-                ::invalid_uhs_id:
+            case cbdc::transaction::validation::proof_error_code ::
+                invalid_uhs_id:
                 return "One or more UHS ID commitments were malformed";
-            case cbdc::transaction::validation::proof_error_code
-                ::invalid_signature_key:
+            case cbdc::transaction::validation::proof_error_code ::
+                invalid_signature_key:
                 return "Constructing the consistency-proof "
                        "verification key failed";
-            case cbdc::transaction::validation::proof_error_code
-                ::inconsistent_value:
+            case cbdc::transaction::validation::proof_error_code ::
+                inconsistent_value:
                 return "The values committed to by a UHS ID commitment and "
                        "its auxiliary commitment are not equal";
-            case cbdc::transaction::validation::proof_error_code
-                ::out_of_range:
+            case cbdc::transaction::validation::proof_error_code ::
+                out_of_range:
                 return "One or more output values lay outside their proven "
                        "range";
-            case cbdc::transaction::validation::proof_error_code
-                ::wrong_sum:
+            case cbdc::transaction::validation::proof_error_code ::wrong_sum:
                 return "Input values do not equal output values";
             default:
                 return "Unknown error";

--- a/src/uhs/transaction/validation.hpp
+++ b/src/uhs/transaction/validation.hpp
@@ -58,11 +58,11 @@ namespace cbdc::transaction::validation {
     /// A proof verification error
     enum class proof_error_code : uint8_t {
         invalid_auxiliary, ///< deserializing the auxiliary commitment failed
-        invalid_uhs_id, ///< deserializing the UHS ID failed
+        invalid_uhs_id,    ///< deserializing the UHS ID failed
         invalid_signature_key, ///< constructing consistency key failed
-        inconsistent_value, ///< consistency proof did not verify
-        out_of_range,  ///< range proof did not verify
-        wrong_sum, ///< auxiliaries did not sum as-required
+        inconsistent_value,    ///< consistency proof did not verify
+        out_of_range,          ///< range proof did not verify
+        wrong_sum,             ///< auxiliaries did not sum as-required
     };
 
     /// An error that may occur when verifying transaction proof
@@ -128,9 +128,11 @@ namespace cbdc::transaction::validation {
     /// A transaction can fail validation because of an error in the inputs,
     /// outputs, witnesses, or because the transaction-local invariants
     /// do not hold.
-    using tx_error = std::
-        variant<input_error, output_error, witness_error, tx_error_code,
-            proof_error>;
+    using tx_error = std::variant<input_error,
+                                  output_error,
+                                  witness_error,
+                                  tx_error_code,
+                                  proof_error>;
 
     /// \brief Runs static validation checks on the given transaction
     ///

--- a/src/uhs/transaction/wallet.hpp
+++ b/src/uhs/transaction/wallet.hpp
@@ -176,12 +176,15 @@ namespace cbdc::transaction {
         /// \param tx the transaction to fetch spending keys for
         /// \return the list of keypairs (or std::nullopt if any output is
         ///         unspendable)
-        auto spending_keys(const full_tx& tx)
-            -> std::optional<std::vector<std::pair<privkey_t, pubkey_t>>> const;
+        auto spending_keys(const full_tx& tx) -> std::optional<
+            std::vector<std::pair<privkey_t, pubkey_t>>> const;
 
         /// Signs each of the transaction's inputs using Schnorr signatures.
         /// \param tx the transaction whose inputs to sign.
-        void sign(full_tx& tx, std::vector<std::pair<privkey_t, pubkey_t>> spend_keys) const;
+        /// \param spend_keys the keys necessary to sign the transaction
+        void
+        sign(full_tx& tx,
+             std::vector<std::pair<privkey_t, pubkey_t>> spend_keys) const;
 
         /// Checks if the input is spendable by the current wallet.
         /// \param in the input to check.
@@ -237,7 +240,6 @@ namespace cbdc::transaction {
         /// Queue of spendable inputs, oldest first.
         std::list<input> m_spend_queue;
 
-
         /// Locks access to m_keys and related members m_pubkeys and
         /// m_witness_programs.
         /// \warning Do not lock simultaneously with m_utxos_mut.
@@ -263,23 +265,31 @@ namespace cbdc::transaction {
             -> std::optional<transaction::input>;
 
         struct GensDeleter {
-            GensDeleter(secp256k1_context* ctx) : m_ctx(ctx) {}
+            explicit GensDeleter(secp256k1_context* ctx) : m_ctx(ctx) {}
 
-            void operator()(secp256k1_bulletproofs_generators* gens) {
+            void operator()(secp256k1_bulletproofs_generators* gens) const {
                 secp256k1_bulletproofs_generators_destroy(m_ctx, gens);
             }
 
             secp256k1_context* m_ctx;
         };
 
+        /// should be twice the bitcount of the range-proof's upper bound
+        ///
+        /// e.g., if proving things in the range [0, 2^64-1], it should be 128.
+        static const inline auto generator_count = 128;
+
         std::unique_ptr<secp256k1_bulletproofs_generators, GensDeleter>
-            m_generators{secp256k1_bulletproofs_generators_create(m_secp.get(),
-                128), GensDeleter(m_secp.get())};
+            m_generators{
+                secp256k1_bulletproofs_generators_create(m_secp.get(),
+                    generator_count),
+                GensDeleter(m_secp.get())};
 
         static const inline auto m_secp
             = std::unique_ptr<secp256k1_context,
                               decltype(&secp256k1_context_destroy)>(
-                secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY),
+                secp256k1_context_create(SECP256K1_CONTEXT_SIGN
+                                         | SECP256K1_CONTEXT_VERIFY),
                 &secp256k1_context_destroy);
 
         static const inline auto m_random_source

--- a/src/uhs/twophase/locking_shard/interface.hpp
+++ b/src/uhs/twophase/locking_shard/interface.hpp
@@ -6,8 +6,8 @@
 #ifndef OPENCBDC_TX_SRC_LOCKING_SHARD_LOCKING_SHARD_INTERFACE_H_
 #define OPENCBDC_TX_SRC_LOCKING_SHARD_LOCKING_SHARD_INTERFACE_H_
 
-#include "util/common/hash.hpp"
 #include "uhs/transaction/transaction.hpp"
+#include "util/common/hash.hpp"
 
 #include <optional>
 #include <variant>

--- a/src/uhs/twophase/locking_shard/locking_shard.cpp
+++ b/src/uhs/twophase/locking_shard/locking_shard.cpp
@@ -61,12 +61,16 @@ namespace cbdc::locking_shard {
             }
             in.seekg(0, std::ios::beg);
             auto deser = istream_serializer(in);
-            m_uhs.clear();
+            m_proofs.clear();
             static constexpr auto uhs_size_factor = 2;
             auto bucket_count = static_cast<unsigned long>(sz / cbdc::hash_size
                                                            * uhs_size_factor);
+            m_proofs.rehash(bucket_count);
             m_uhs.rehash(bucket_count);
-            deser >> m_uhs;
+            deser >> m_proofs;
+            for (const auto& [k, v] : m_proofs) {
+                m_uhs.insert(k);
+            }
             return true;
         }
         return false;

--- a/src/uhs/twophase/locking_shard/locking_shard.hpp
+++ b/src/uhs/twophase/locking_shard/locking_shard.hpp
@@ -9,8 +9,8 @@
 #include "client.hpp"
 #include "interface.hpp"
 #include "status_interface.hpp"
-#include "uhs/transaction/transaction.hpp"
 #include "uhs/transaction/messages.hpp"
+#include "uhs/transaction/transaction.hpp"
 #include "util/common/cache_set.hpp"
 #include "util/common/hash.hpp"
 #include "util/common/hashmap.hpp"
@@ -134,7 +134,8 @@ namespace cbdc::locking_shard {
         std::shared_ptr<logging::log> m_logger;
         mutable std::shared_mutex m_mut;
         std::unordered_set<hash_t, hashing::null> m_uhs{};
-        std::unordered_map<hash_t, transaction::compact_output, hashing::null> m_proofs{};
+        std::unordered_map<hash_t, transaction::compact_output, hashing::null>
+            m_proofs{};
         std::unordered_set<hash_t, hashing::null> m_locked;
         std::unordered_map<hash_t, prepared_dtx, hashing::null>
             m_prepared_dtxs;

--- a/src/uhs/twophase/sentinel_2pc/controller.hpp
+++ b/src/uhs/twophase/sentinel_2pc/controller.hpp
@@ -11,11 +11,11 @@
 #include "server.hpp"
 #include "uhs/sentinel/format.hpp"
 #include "uhs/transaction/messages.hpp"
+#include "uhs/transaction/transaction.hpp"
 #include "uhs/twophase/coordinator/client.hpp"
 #include "util/common/config.hpp"
 #include "util/common/hashmap.hpp"
 #include "util/network/connection_manager.hpp"
-#include "uhs/transaction/transaction.hpp"
 
 #include <secp256k1.h>
 #include <secp256k1_bulletproofs.h>

--- a/src/util/common/commitment.cpp
+++ b/src/util/common/commitment.cpp
@@ -3,47 +3,58 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "keys.hpp"
 #include "commitment.hpp"
 
 #include "crypto/sha256.h"
+#include "keys.hpp"
 
-#include <cstring>
-#include <vector>
 #include <array>
-#include <sstream>
-
+#include <cstring>
 #include <secp256k1_generator.h>
+#include <sstream>
+#include <vector>
 
 namespace cbdc {
-    auto commit(const secp256k1_context* ctx, uint64_t value, const hash_t blind) -> std::optional<secp256k1_pedersen_commitment> {
+    auto
+    commit(const secp256k1_context* ctx, uint64_t value, const hash_t& blind)
+        -> std::optional<secp256k1_pedersen_commitment> {
         secp256k1_pedersen_commitment commit{};
-        auto res = secp256k1_pedersen_commit(ctx, &commit, blind.data(), value, secp256k1_generator_h);
-        if (res != 1) {
+        auto res = secp256k1_pedersen_commit(ctx,
+                                             &commit,
+                                             blind.data(),
+                                             value,
+                                             secp256k1_generator_h);
+        if(res != 1) {
             return std::nullopt;
         }
 
         return commit;
     }
 
-    auto serialize_commitment(const secp256k1_context* ctx, secp256k1_pedersen_commitment comm) -> commitment_t {
+    auto serialize_commitment(const secp256k1_context* ctx,
+                              secp256k1_pedersen_commitment comm)
+        -> commitment_t {
         commitment_t c{};
         secp256k1_pedersen_commitment_serialize(ctx, c.data(), &comm);
         return c;
     }
 
-    auto make_commitment(const secp256k1_context* ctx, uint64_t value, const hash_t blind) -> std::optional<commitment_t> {
+    auto make_commitment(const secp256k1_context* ctx,
+                         uint64_t value,
+                         const hash_t& blind) -> std::optional<commitment_t> {
         auto comm = commit(ctx, value, blind);
-        if (!comm.has_value()) {
+        if(!comm.has_value()) {
             return std::nullopt;
         }
 
         return serialize_commitment(ctx, comm.value());
     }
 
-    auto make_xonly_commitment(const secp256k1_context* ctx, uint64_t value, const hash_t blind) -> std::optional<hash_t> {
+    auto make_xonly_commitment(const secp256k1_context* ctx,
+                               uint64_t value,
+                               const hash_t& blind) -> std::optional<hash_t> {
         auto lemma = make_commitment(ctx, value, blind);
-        if (!lemma.has_value() || lemma.value().front() != 0x08) {
+        if(!lemma.has_value() || lemma.value().front() != 0x08) {
             return std::nullopt;
         }
 
@@ -53,22 +64,27 @@ namespace cbdc {
         return commitment;
     }
 
-    auto deserialize_commitment(const secp256k1_context* ctx, commitment_t comm) -> std::optional<secp256k1_pedersen_commitment> {
+    auto deserialize_commitment(const secp256k1_context* ctx,
+                                commitment_t comm)
+        -> std::optional<secp256k1_pedersen_commitment> {
         secp256k1_pedersen_commitment commitment{};
-        if (secp256k1_pedersen_commitment_parse(ctx, &commitment, comm.data()) != 1) {
+        if(secp256k1_pedersen_commitment_parse(ctx, &commitment, comm.data())
+           != 1) {
             return std::nullopt;
         }
 
         return commitment;
     }
 
-    auto expand_xonly_commitment(const secp256k1_context* ctx, hash_t comm) -> std::optional<secp256k1_pedersen_commitment> {
+    auto expand_xonly_commitment(const secp256k1_context* ctx, hash_t& comm)
+        -> std::optional<secp256k1_pedersen_commitment> {
         commitment_t commit{};
         commit[0] = 0x08;
         std::memcpy(commit.data() + 1, comm.data(), hash_size);
 
         secp256k1_pedersen_commitment commitment{};
-        if (secp256k1_pedersen_commitment_parse(ctx, &commitment, commit.data()) != 1) {
+        if(secp256k1_pedersen_commitment_parse(ctx, &commitment, commit.data())
+           != 1) {
             return std::nullopt;
         }
 

--- a/src/util/common/commitment.hpp
+++ b/src/util/common/commitment.hpp
@@ -10,7 +10,6 @@
 #include "keys.hpp"
 
 #include <optional>
-
 #include <secp256k1_generator.h>
 
 namespace cbdc {
@@ -18,28 +17,34 @@ namespace cbdc {
     ///
     /// \param ctx secp256k1 context initialized for signing and commitment
     /// \param value the value to commit to
-    /// \param blinder a 32-byte blinding factor
+    /// \param blind a 32-byte blinding factor
     /// \return a pedersen commitment, or nullopt if making the commitment
     ///         failed
-    auto commit(const secp256k1_context* ctx, uint64_t value, const hash_t blind) -> std::optional<secp256k1_pedersen_commitment>;
+    auto
+    commit(const secp256k1_context* ctx, uint64_t value, const hash_t& blind)
+        -> std::optional<secp256k1_pedersen_commitment>;
 
     /// Serializes a Pedersen commitment
     ///
     /// \param ctx secp256k1 context initialized for signing and commitment
     /// \param comm the commitment to serialize
     /// \return a serialized pedersen commitment
-    auto serialize_commitment(const secp256k1_context* ctx, secp256k1_pedersen_commitment comm) -> commitment_t;
+    auto serialize_commitment(const secp256k1_context* ctx,
+                              secp256k1_pedersen_commitment comm)
+        -> commitment_t;
 
     /// Creates and serializes a Pedersen commitment
     ///
-    /// A shortcut to to \ref commit and \ref serialize_commit
+    /// A shortcut to to \ref commit and \ref serialize_commitment
     ///
     /// \param ctx secp256k1 context initialized for signing and commitment
     /// \param value the value to commit to
     /// \param blinder a 32-byte blinding factor
     /// \return a serialized pedersen commitment, or nullopt if making the
     ///         commitment failed
-    auto make_commitment(const secp256k1_context* ctx, uint64_t value, const hash_t blinder) -> std::optional<commitment_t>;
+    auto make_commitment(const secp256k1_context* ctx,
+                         uint64_t value,
+                         const hash_t& blinder) -> std::optional<commitment_t>;
 
     /// Attempts to create a Pedersen commitment and serialize it into 32-bytes
     ///
@@ -61,7 +66,9 @@ namespace cbdc {
     /// \param blinder a 32-byte blinding factor
     /// \return a serialized pedersen commitment, or nullopt if the commitment
     ///         could not be represented in 32 bytes
-    auto make_xonly_commitment(const secp256k1_context* ctx, uint64_t value, const hash_t blinder) -> std::optional<hash_t>;
+    auto make_xonly_commitment(const secp256k1_context* ctx,
+                               uint64_t value,
+                               const hash_t& blinder) -> std::optional<hash_t>;
 
     /// Attempts to deserialize a Pedersen commitment
     ///
@@ -69,7 +76,9 @@ namespace cbdc {
     /// \param comm a 33-byte serialized Pedersen commitment
     /// \return the deserialized commitment, or std::nullopt if the input
     ///         was invalid
-    auto deserialize_commitment(const secp256k1_context* ctx, commitment_t comm) -> std::optional<secp256k1_pedersen_commitment>;
+    auto deserialize_commitment(const secp256k1_context* ctx,
+                                commitment_t comm)
+        -> std::optional<secp256k1_pedersen_commitment>;
 
     /// Attempts to deserialize an xonly Pedersen commitment
     ///
@@ -77,7 +86,8 @@ namespace cbdc {
     /// \param comm a 32-byte serialized x-only Pedersen commitment
     /// \return the deserialized commitment, or std::nullopt if the input
     ///         was invalid
-    auto expand_xonly_commitment(const secp256k1_context* ctx, hash_t comm) -> std::optional<secp256k1_pedersen_commitment>;
+    auto expand_xonly_commitment(const secp256k1_context* ctx, hash_t& comm)
+        -> std::optional<secp256k1_pedersen_commitment>;
 }
 
 #endif // OPENCBDC_TX_SRC_COMMON_COMMITMENT_H_

--- a/src/util/common/keys.hpp
+++ b/src/util/common/keys.hpp
@@ -8,9 +8,8 @@
 
 #include <array>
 #include <cstring>
-#include <vector>
-
 #include <secp256k1_bulletproofs.h>
+#include <vector>
 
 struct secp256k1_context_struct;
 using secp256k1_context = struct secp256k1_context_struct;
@@ -37,7 +36,8 @@ namespace cbdc {
     /// A range-proof
     /// \tparam N the size (in bytes) of the proof (dependent on the range
     ///           being proven.
-    template <size_t N = SECP256K1_BULLETPROOFS_RANGEPROOF_UNCOMPRESSED_MAX_LENGTH_>
+    template<size_t N
+             = SECP256K1_BULLETPROOFS_RANGEPROOF_UNCOMPRESSED_MAX_LENGTH_>
     using rangeproof_t = std::array<unsigned char, N>;
 
     /// Generates a public key from the specified private key.

--- a/src/util/serialization/format.hpp
+++ b/src/util/serialization/format.hpp
@@ -16,9 +16,9 @@
 #include <cassert>
 #include <cstdint>
 #include <limits>
+#include <map>
 #include <optional>
 #include <set>
-#include <map>
 #include <unordered_map>
 #include <unordered_set>
 #include <variant>
@@ -237,8 +237,7 @@ namespace cbdc {
     /// statically-casted.
     /// \see \ref cbdc::operator<<(serializer&, T)
     template<typename K, typename V>
-    auto operator<<(serializer& ser,
-                    const std::map<K, V>& map)
+    auto operator<<(serializer& ser, const std::map<K, V>& map)
         -> serializer& {
         auto len = static_cast<uint64_t>(map.size());
         ser << len;
@@ -252,9 +251,7 @@ namespace cbdc {
     /// Deserializes a map of key-value pairs.
     /// \see \ref cbdc::operator<<(serializer&, const std::map<K, V>&)
     template<typename K, typename V>
-    auto operator>>(serializer& deser,
-                    std::map<K, V>& map)
-        -> serializer& {
+    auto operator>>(serializer& deser, std::map<K, V>& map) -> serializer& {
         auto len = uint64_t();
         if(!(deser >> len)) {
             return deser;

--- a/tests/unit/locking_shard/format_test.cpp
+++ b/tests/unit/locking_shard/format_test.cpp
@@ -13,10 +13,10 @@ class locking_shard_format_test : public ::testing::Test {
     cbdc::buffer_serializer m_ser{m_target_packet};
     cbdc::buffer_serializer m_deser{m_target_packet};
 
-    cbdc::locking_shard::tx m_tx{std::optional<cbdc::hash_t>({'a', 'b', 'c'}),
-                                 {{'d', 'e', 'f'}, {'g', 'h', 'i'}},
-                                 {{{'w'}, {'x'}, {'y'}, {'z'}},
-                                    {{'z'}, {'z'}, {'z'}, {'z'}}}};
+    cbdc::locking_shard::tx m_tx{
+        std::optional<cbdc::hash_t>({'a', 'b', 'c'}),
+        {{'d', 'e', 'f'}, {'g', 'h', 'i'}},
+        {{{'w'}, {'x'}, {'y'}, {'z'}}, {{'z'}, {'z'}, {'z'}, {'z'}}}};
 };
 
 TEST_F(locking_shard_format_test, tx) {

--- a/tests/unit/message_test.cpp
+++ b/tests/unit/message_test.cpp
@@ -470,7 +470,8 @@ TEST_F(PacketIOTest, aggregate_tx_notify_request) {
 
 TEST_F(PacketIOTest, variant) {
     auto outpoint = cbdc::transaction::out_point{{'a', 'b', 'c', 'd'}, 1};
-    auto output = cbdc::transaction::output{{'b'}, {'c'}, {'d'}, {'e'}, {'f'}, {'g'}};
+    auto output
+        = cbdc::transaction::output{{'b'}, {'c'}, {'d'}, {'e'}, {'f'}, {'g'}};
     auto var = std::variant<cbdc::transaction::out_point,
                             cbdc::transaction::output>(outpoint);
     m_ser << var;

--- a/tests/unit/shard_test.cpp
+++ b/tests/unit/shard_test.cpp
@@ -60,8 +60,8 @@ TEST_F(shard_test, digest_tx_valid) {
     cbdc::transaction::compact_tx ctx{};
     ctx.m_id = {'a'};
     ctx.m_inputs = {{0}, {3}, {6}, {100}};
-    ctx.m_outputs = {{{'b'}, {'c'}, {'d'}, {'e'}},
-                     {{'h'}, {'i'}, {'j'}, {'k'}}};
+    ctx.m_outputs
+        = {{{'b'}, {'c'}, {'d'}, {'e'}}, {{'h'}, {'i'}, {'j'}, {'k'}}};
 
     auto res = m_shard.digest_transaction(ctx);
     ASSERT_TRUE(
@@ -80,8 +80,8 @@ TEST_F(shard_test, digest_tx_empty_inputs) {
     cbdc::transaction::compact_tx ctx{};
     ctx.m_id = {'a'};
     ctx.m_inputs = {};
-    ctx.m_outputs = {{{'b'}, {'c'}, {'d'}, {'e'}},
-                     {{'h'}, {'i'}, {'j'}, {'k'}}};
+    ctx.m_outputs
+        = {{{'b'}, {'c'}, {'d'}, {'e'}}, {{'h'}, {'i'}, {'j'}, {'k'}}};
 
     auto res = m_shard.digest_transaction(ctx);
     ASSERT_TRUE(std::holds_alternative<cbdc::watchtower::tx_error>(res));
@@ -97,8 +97,8 @@ TEST_F(shard_test, digest_tx_inputs_dne) {
     cbdc::transaction::compact_tx ctx{};
     ctx.m_id = {'a'};
     ctx.m_inputs = {{0}, {7}, {8}, {100}};
-    ctx.m_outputs = {{{'b'}, {'c'}, {'d'}, {'e'}},
-                     {{'h'}, {'i'}, {'j'}, {'k'}}};
+    ctx.m_outputs
+        = {{{'b'}, {'c'}, {'d'}, {'e'}}, {{'h'}, {'i'}, {'j'}, {'k'}}};
 
     auto res = m_shard.digest_transaction(ctx);
     ASSERT_TRUE(std::holds_alternative<cbdc::watchtower::tx_error>(res));
@@ -123,8 +123,8 @@ TEST_F(shard_test, digest_block_valid) {
     cbdc::transaction::compact_tx valid_ctx{};
     valid_ctx.m_id = {'a'};
     valid_ctx.m_inputs = {{0}, {7}, {100}, {8}};
-    valid_ctx.m_outputs = {{{'b'}, {'c'}, {'d'}, {'e'}},
-                           {{'h'}, {'i'}, {'j'}, {'k'}}};
+    valid_ctx.m_outputs
+        = {{{'b'}, {'c'}, {'d'}, {'e'}}, {{'h'}, {'i'}, {'j'}, {'k'}}};
 
     auto valid_res = m_shard.digest_transaction(valid_ctx);
     ASSERT_TRUE(
@@ -141,8 +141,8 @@ TEST_F(shard_test, digest_block_valid) {
     cbdc::transaction::compact_tx invalid_ctx{};
     invalid_ctx.m_id = {'a'};
     invalid_ctx.m_inputs = {{0}, {3}, {4}, {5}, {6}, {100}};
-    invalid_ctx.m_outputs = {{{'b'}, {'c'}, {'d'}, {'e'}},
-                             {{'h'}, {'i'}, {'j'}, {'k'}}};
+    invalid_ctx.m_outputs
+        = {{{'b'}, {'c'}, {'d'}, {'e'}}, {{'h'}, {'i'}, {'j'}, {'k'}}};
     auto invalid_res = m_shard.digest_transaction(invalid_ctx);
     ASSERT_TRUE(
         std::holds_alternative<cbdc::watchtower::tx_error>(invalid_res));

--- a/tests/unit/uhs_test.cpp
+++ b/tests/unit/uhs_test.cpp
@@ -3,15 +3,14 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "uhs/transaction/transaction.hpp"
 #include "util/common/hash.hpp"
 #include "util/common/hashmap.hpp"
-#include "uhs/transaction/transaction.hpp"
-
-#include <leveldb/db.h>
-#include <unordered_map>
 
 #include <filesystem>
 #include <gtest/gtest.h>
+#include <leveldb/db.h>
+#include <unordered_map>
 
 class uhs_test : public ::testing::Test {
   protected:
@@ -35,18 +34,18 @@ class uhs_test : public ::testing::Test {
     leveldb::WriteOptions m_write_options;
 
     std::unordered_map<cbdc::hash_t,
-        cbdc::transaction::compact_output, cbdc::hashing::null> m_proofs{};
+                       cbdc::transaction::compact_output,
+                       cbdc::hashing::null>
+        m_proofs{};
 
     static constexpr const auto m_db_dir = "test_db";
 };
 
 TEST_F(uhs_test, leveldb_roundtrip) {
-    cbdc::transaction::compact_output o {
-        {'a', 'b', 'c', 'd'},
-        {'e', 'f', 'g', 'h'},
-        {'i', 'j', 'k', 'l'},
-        {'m', 'n', 'o', 'p'}
-    };
+    cbdc::transaction::compact_output o{{'a', 'b', 'c', 'd'},
+                                        {'e', 'f', 'g', 'h'},
+                                        {'i', 'j', 'k', 'l'},
+                                        {'m', 'n', 'o', 'p'}};
 
     std::array<char, 32> k;
     std::memcpy(k.data(), o.m_id.data(), k.size());
@@ -72,12 +71,10 @@ TEST_F(uhs_test, leveldb_roundtrip) {
 }
 
 TEST_F(uhs_test, map_roundtrip) {
-    cbdc::transaction::compact_output o {
-        {'a', 'b', 'c', 'd'},
-        {'e', 'f', 'g', 'h'},
-        {'i', 'j', 'k', 'l'},
-        {'m', 'n', 'o', 'p'}
-    };
+    cbdc::transaction::compact_output o{{'a', 'b', 'c', 'd'},
+                                        {'e', 'f', 'g', 'h'},
+                                        {'i', 'j', 'k', 'l'},
+                                        {'m', 'n', 'o', 'p'}};
 
     m_proofs.emplace(o.m_id, o);
     const auto& p = m_proofs[o.m_id];

--- a/tests/unit/validation_test.cpp
+++ b/tests/unit/validation_test.cpp
@@ -113,7 +113,7 @@ TEST_F(WalletTxValidationTest, asymmetric_inout_set) {
     auto err = cbdc::transaction::validation::check_proof(ctx);
     ASSERT_TRUE(err.has_value());
     ASSERT_EQ(err.value().m_code,
-        cbdc::transaction::validation::proof_error_code::wrong_sum);
+              cbdc::transaction::validation::proof_error_code::wrong_sum);
 }
 
 TEST_F(WalletTxValidationTest, witness_missing_witness_program_type) {

--- a/tests/util.cpp
+++ b/tests/util.cpp
@@ -45,9 +45,11 @@ namespace cbdc::test {
         tx.m_id = id;
         tx.m_inputs = ins;
         std::vector<transaction::compact_output> proofs{};
-        std::transform(outs.begin(), outs.end(), std::back_inserter(proofs),
+        std::transform(outs.begin(),
+                       outs.end(),
+                       std::back_inserter(proofs),
                        [](hash_t h) -> transaction::compact_output {
-                        return {h, {}, {}, {}};
+                           return {h, {}, {}, {}};
                        });
         tx.m_outputs = proofs;
         return tx;

--- a/tools/bench/atomizer-cli-watchtower.cpp
+++ b/tools/bench/atomizer-cli-watchtower.cpp
@@ -406,13 +406,15 @@ auto main(int argc, char** argv) -> int {
                 for(const auto& it : pending_txs) {
                     cbdc::transaction::compact_tx ctx{it.second};
                     std::vector<cbdc::hash_t> uhs_ids{};
-                    std::transform(ctx.m_outputs.begin(),
-                                   ctx.m_outputs.end(),
-                                   std::back_inserter(uhs_ids),
-                                   [](const cbdc::transaction::compact_output& p) { return p.m_id; });
+                    std::transform(
+                        ctx.m_outputs.begin(),
+                        ctx.m_outputs.end(),
+                        std::back_inserter(uhs_ids),
+                        [](const cbdc::transaction::compact_output& p) {
+                            return p.m_id;
+                        });
 
-                    key_uhs_ids.emplace(
-                        std::make_pair(ctx.m_id, uhs_ids));
+                    key_uhs_ids.emplace(std::make_pair(ctx.m_id, uhs_ids));
                 }
             }
             watchtower_client->request_status_update(
@@ -545,12 +547,14 @@ auto main(int argc, char** argv) -> int {
                 for(const auto& it : pending_txs) {
                     cbdc::transaction::compact_tx ctx{it.second};
                     std::vector<cbdc::hash_t> uhs_ids{};
-                    std::transform(ctx.m_outputs.begin(),
-                                   ctx.m_outputs.end(),
-                                   std::back_inserter(uhs_ids),
-                                   [](const cbdc::transaction::compact_output& p) { return p.m_id; });
-                    key_uhs_ids.emplace(
-                        std::make_pair(ctx.m_id, uhs_ids));
+                    std::transform(
+                        ctx.m_outputs.begin(),
+                        ctx.m_outputs.end(),
+                        std::back_inserter(uhs_ids),
+                        [](const cbdc::transaction::compact_output& p) {
+                            return p.m_id;
+                        });
+                    key_uhs_ids.emplace(std::make_pair(ctx.m_id, uhs_ids));
                 }
             }
 

--- a/tools/shard-seeder/shard-seeder.cpp
+++ b/tools/shard-seeder/shard-seeder.cpp
@@ -124,7 +124,8 @@ auto main(int argc, char** argv) -> int {
                     for(size_t tx_idx = 0; tx_idx != num_utxos; tx_idx++) {
                         tx.m_inputs[0].m_prevout.m_index = tx_idx;
                         cbdc::transaction::compact_tx ctx(tx);
-                        const cbdc::hash_t& output_hash = ctx.m_outputs[0].m_id;
+                        const cbdc::hash_t& output_hash
+                            = ctx.m_outputs[0].m_id;
                         if(output_hash[0] >= shard_start
                            && output_hash[0] <= shard_end) {
                             std::array<char, sizeof(output_hash)> hash_arr{};
@@ -157,7 +158,8 @@ auto main(int argc, char** argv) -> int {
                     for(size_t tx_idx = 0; tx_idx != num_utxos; tx_idx++) {
                         tx.m_inputs[0].m_prevout.m_index = tx_idx;
                         cbdc::transaction::compact_tx ctx(tx);
-                        const cbdc::hash_t& output_hash = ctx.m_outputs[0].m_id;
+                        const cbdc::hash_t& output_hash
+                            = ctx.m_outputs[0].m_id;
                         if(output_hash[0] >= shard_start
                            && output_hash[0] <= shard_end) {
                             ser << output_hash;


### PR DESCRIPTION
Shard seeder updated to support temper detection work. Atomizer database will store uhs_id and proofs, 2PC will save to file uhs_id and proofs for m_proofs. 